### PR TITLE
docs: fix simple typo, verticle -> vertical

### DIFF
--- a/samples/micropython/rccar/main.py
+++ b/samples/micropython/rccar/main.py
@@ -61,7 +61,7 @@ def joystickLoop(robot, eventFile):
                     return robot.inactive()
             elif t == 3:
                 if c == 1:
-                    # Left stick & verticle:
+                    # Left stick & vertical:
                     speed = 0
                     if v < 32768:
                         # up:


### PR DESCRIPTION
There is a small typo in samples/micropython/rccar/main.py.

Should read `vertical` rather than `verticle`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md